### PR TITLE
Task.5-1 データベース周りの環境設定完了

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
-  gem 'annotate'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'pry-doc'
@@ -35,6 +34,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'annotate'
 end
 
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -14,8 +14,8 @@ default: &default
   encoding: utf8
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
-  password:
-  host: localhost
+  password: root
+  host: 127.0.0.1
 
 development:
   <<: *default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.2'
+
+services:
+  database:
+    restart: always
+    image: mysql:latest
+    ports:
+      - 3306:3306
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - mysql-datavolume:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+
+volumes:
+  mysql-datavolume:
+    driver: local


### PR DESCRIPTION
### 作業内容

①Docker で mysql2 の導入
②database.yml の調整

### 作業中エラー対応
docker-compose up -d を実行した後、port is already allocatedエラーが出る
①docker-compose.ymlファイル内で設定しているポート番号3306を使っている場所を特定するため
`sudo lsof -i:3306` コマンドを実行
②該当場所をkillコマンドで消去 `sudo kill 18650`
③再度、docker-compose up -dコマンドを実行が再度エラー
④ `docker ps` でdockerの立ち上げ状況を確認
⑤  `docker stop CONTAINER_ID` で動いていたコンテナをstop
⑥再度、docker-compose up -dコマンドを実行
無事解決した

### 参考URL
https://freelance.cat-algorithm.com/setup-database-by-docker/
https://qiita.com/hiro0053b/items/c3306997c8ff029f720a